### PR TITLE
Add basic Dioxus app

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-dioxus = "0.7.0-alpha.1"
+dioxus = { version = "0.7.0-alpha.1", features = ["desktop", "web"] }
 dioxus-desktop = "0.7.0-alpha.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,17 @@
+use dioxus::prelude::*;
+
 fn main() {
-    println!("Hello, world!");
+    dioxus::launch(App);
+}
+
+#[component]
+fn App() -> Element {
+    let mut count = use_signal(|| 0);
+
+    rsx! {
+        div {
+            h1 { "Welcome to Dioxus!" }
+            button { onclick: move |_| count += 1, "Clicked {count} times" }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- implement a simple Dioxus `App` component and launch it
- enable desktop and web features in `Cargo.toml`

## Testing
- `cargo check -q` *(fails: system library `gobject-2.0` not found)*
 